### PR TITLE
remove support for SDK v1.9.1 & v1.9.2 for macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,9 @@ jobs:
           - ubuntu-latest
           # - windows-latest
         version:
-          # - latest
-          - 1.9.1
+          - latest # actual
+          - 1.10.0 # actual
+          - 1.9.3 # oldest supported
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Download the latest version of dove
   uses: ./
   with:
     # optional, can be omitted
+    # possible values: version (1.10.0 or 1.9.3) or "latest"
     version: latest
 
 - name: usage

--- a/action.yml
+++ b/action.yml
@@ -26,20 +26,8 @@ outputs:
 runs:
   using: "composite"
   steps:
-    # First two versions of SDK was not packed into zip for macOS, just pkg.
-    - name: download pkg (<= 1.9.2)
-      if: (runner.os == 'macOS' && (matrix.version == '1.9.1' || matrix.version == '1.9.2'))
-      shell: bash
-      run: |
-        curl -L --silent --show-error --fail "https://download.panic.com/playdate_sdk/PlaydateSDK-${{ matrix.version }}.pkg" -o PlaydateSDK.pkg
-        sudo installer -store -pkg "PlaydateSDK.pkg" -target /
-        cat ~/.Playdate/config
-        echo "root: $PLAYDATE_SDK_PATH"
-        PLAYDATE_SDK_PATH="$(grep -E '^\s*SDKRoot' ~/.Playdate/config | head -n 1 | awk '{print $2}')"
-        echo "PLAYDATE_SDK_PATH=$PLAYDATE_SDK_PATH" >> $GITHUB_ENV
-
-    - name: download pkg (>= 1.9.3)
-      if: (runner.os == 'macOS' && (matrix.version != '1.9.1' || matrix.version != '1.9.2'))
+    - name: download pkg
+      if: runner.os == 'macOS'
       shell: bash
       run: |
         curl -L --silent --show-error --fail "https://download.panic.com/playdate_sdk/PlaydateSDK-${{ matrix.version }}.zip" -o sdk.zip

--- a/action.yml
+++ b/action.yml
@@ -26,16 +26,22 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: download pkg
-      if: runner.os == 'macOS'
+    # First two versions of SDK was not packed into zip for macOS, just pkg.
+    - name: download pkg (<= 1.9.2)
+      if: (runner.os == 'macOS' && (matrix.version == '1.9.1' || matrix.version == '1.9.2'))
       shell: bash
-      # env:
-      #   SECRET_TOKEN: ${{inputs.token}}
       run: |
-        # matrix.version < 1.9.3:
-        #   url: https://download.panic.com/playdate_sdk/PlaydateSDK-${{ matrix.version }}.pkg
-        # matrix.version >= 1.9.3:
-        #   url: https://download.panic.com/playdate_sdk/PlaydateSDK-${{ matrix.version }}.zip
+        curl -L --silent --show-error --fail "https://download.panic.com/playdate_sdk/PlaydateSDK-${{ matrix.version }}.pkg" -o PlaydateSDK.pkg
+        sudo installer -store -pkg "PlaydateSDK.pkg" -target /
+        cat ~/.Playdate/config
+        echo "root: $PLAYDATE_SDK_PATH"
+        PLAYDATE_SDK_PATH="$(grep -E '^\s*SDKRoot' ~/.Playdate/config | head -n 1 | awk '{print $2}')"
+        echo "PLAYDATE_SDK_PATH=$PLAYDATE_SDK_PATH" >> $GITHUB_ENV
+
+    - name: download pkg (>= 1.9.3)
+      if: (runner.os == 'macOS' && (matrix.version != '1.9.1' || matrix.version != '1.9.2'))
+      shell: bash
+      run: |
         curl -L --silent --show-error --fail "https://download.panic.com/playdate_sdk/PlaydateSDK-${{ matrix.version }}.zip" -o sdk.zip
         unzip sdk.zip
         sudo installer -store -pkg "PlaydateSDK.pkg" -target /


### PR DESCRIPTION
Because [this][].

Panic removed following versions from CDN:
- [1.9.1][]
- [1.9.2][]

[this]: https://github.com/pd-rs/get-playdate-sdk/runs/6099670414?check_suite_focus=true#step:3:18
[1.9.1]: https://download.panic.com/playdate_sdk/PlaydateSDK-1.9.1.zip
[1.9.2]: https://download.panic.com/playdate_sdk/PlaydateSDK-1.9.2.zip