### PR TITLE
install linux arm toolchain dependencies with sdk

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,12 @@ runs:
         PLAYDATE_SDK_PATH="$(grep -E '^\s*SDKRoot' ~/.Playdate/config | head -n 1 | awk '{print $2}')"
         echo "PLAYDATE_SDK_PATH=$PLAYDATE_SDK_PATH" >> $GITHUB_ENV
 
+    - name: install apt dependencies
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt install -y gcc-arm-none-eabi
+
     - name: download tar.gz
       if: runner.os == 'Linux'
       shell: bash


### PR DESCRIPTION
An ARM GCC toolchain is necessary to build Playdate-ready games written in C or Rust. Feel free to close this if you feel it should be the responsibility of consumers of this action to install an ARM toolchain rather than unconditionally installing it with this action (the toolchain is available in macos and windows, but not linux by default -- see https://github.com/actions/virtual-environments/issues/3892)